### PR TITLE
feat(telegram): emit telegram internal events

### DIFF
--- a/adapters/telegram/src/index.ts
+++ b/adapters/telegram/src/index.ts
@@ -15,4 +15,15 @@ declare module '@satorijs/core' {
   interface Session {
     telegram?: Telegram.Update & Telegram.Internal
   }
+
+  interface Events {
+    'telegram/inline-query'(session: Session): void
+    'telegram/chosen-inline-result'(session: Session): void
+    'telegram/callback-query'(session: Session): void
+    'telegram/shipping-query'(session: Session): void
+    'telegram/pre-checkout-query'(session: Session): void
+    'telegram/poll'(session: Session): void
+    'telegram/poll-answer'(session: Session): void
+    'telegram/chat-member'(session: Session): void
+  }
 }

--- a/adapters/telegram/src/utils.ts
+++ b/adapters/telegram/src/utils.ts
@@ -1,4 +1,4 @@
-import { GuildMember, defineProperty, Logger, User, paramCase } from '@satorijs/satori'
+import { defineProperty, GuildMember, hyphenate, Logger, User } from '@satorijs/satori'
 import { TelegramBot } from './bot'
 import * as Telegram from './types'
 
@@ -49,7 +49,7 @@ export async function handleUpdate(update: Telegram.Update, bot: TelegramBot) {
     const subtype = Object.keys(update).filter(v => v !== 'update_id')[0]
     if (subtype) {
       session.type = 'telegram'
-      session.subtype = paramCase(subtype)
+      session.subtype = hyphenate(subtype)
     }
   }
 

--- a/adapters/telegram/src/utils.ts
+++ b/adapters/telegram/src/utils.ts
@@ -1,4 +1,4 @@
-import { GuildMember, defineProperty, Logger, User } from '@satorijs/satori'
+import { GuildMember, defineProperty, Logger, User, paramCase } from '@satorijs/satori'
 import { TelegramBot } from './bot'
 import * as Telegram from './types'
 
@@ -43,6 +43,13 @@ export async function handleUpdate(update: Telegram.Update, bot: TelegramBot) {
       } else if (update.my_chat_member.old_chat_member.status === 'left') {
         session.type = 'group-added'
       }
+    }
+  } else {
+    // Get update type from field name.
+    const subtype = Object.keys(update).filter(v => v !== 'update_id')[0]
+    if (subtype) {
+      session.type = 'telegram'
+      session.subtype = paramCase(subtype)
     }
   }
 


### PR DESCRIPTION
Support for telegram internal events:
- telegram/inline-query
- telegram/chosen-inline-result
- telegram/callback-query
- telegram/shipping-query
- telegram/pre-checkout-query
- telegram/poll
- telegram/poll-answer
- telegram/chat-member