### PR TITLE
fix(kook): failed to create asset

### DIFF
--- a/adapters/kook/src/bot.ts
+++ b/adapters/kook/src/bot.ts
@@ -65,9 +65,15 @@ export class KookBot<C extends Context = Context, T extends KookBot.Config = Koo
   private async _transformUrl({ type, data }: segment.Parsed) {
     if (data.url.startsWith('file://') || data.url.startsWith('base64://')) {
       const payload = new FormData()
-      payload.append('file', data.url.startsWith('file://')
-        ? createReadStream(data.url.slice(8))
-        : Buffer.from(data.url.slice(9), 'base64'))
+      payload.append(
+        'file',
+        data.url.startsWith('file://')
+          ? createReadStream(data.url.slice(8))
+          : Buffer.from(data.url.slice(9), 'base64'),
+        {
+          filename: 'file',
+        },
+      )
       const { url } = await this.request('POST', '/asset/create', payload, payload.getHeaders())
       data.url = url
     } else if (!data.url.includes('kaiheila')) {
@@ -76,7 +82,9 @@ export class KookBot<C extends Context = Context, T extends KookBot.Config = Koo
         responseType: 'stream',
       })
       const payload = new FormData()
-      payload.append('file', res)
+      payload.append('file', res, {
+        filename: 'file',
+      })
       const { url } = await this.request('POST', '/asset/create', payload, payload.getHeaders())
       data.url = url
       console.log(url)

--- a/adapters/kook/src/bot.ts
+++ b/adapters/kook/src/bot.ts
@@ -65,15 +65,12 @@ export class KookBot<C extends Context = Context, T extends KookBot.Config = Koo
   private async _transformUrl({ type, data }: segment.Parsed) {
     if (data.url.startsWith('file://') || data.url.startsWith('base64://')) {
       const payload = new FormData()
-      payload.append(
-        'file',
-        data.url.startsWith('file://')
-          ? createReadStream(data.url.slice(8))
-          : Buffer.from(data.url.slice(9), 'base64'),
-        {
-          filename: 'file',
-        },
-      )
+      const content = data.url.startsWith('file://')
+        ? createReadStream(data.url.slice(8))
+        : Buffer.from(data.url.slice(9), 'base64')
+      payload.append('file', content, {
+        filename: 'file',
+      })
       const { url } = await this.request('POST', '/asset/create', payload, payload.getHeaders())
       data.url = url
     } else if (!data.url.includes('kaiheila')) {


### PR DESCRIPTION
No file name will cause the server to return error code 40000. Add a file name to avoid the error.

![image](https://user-images.githubusercontent.com/8019167/187451328-917b5980-261e-4c60-b643-99c5139ac7c4.png)

![image](https://user-images.githubusercontent.com/8019167/187451388-8f1a3bd7-fa2b-48e9-a603-c6956d8f5ccf.png)

![image](https://user-images.githubusercontent.com/8019167/187451521-cdd034f0-c111-4f29-a8ee-a2e00ff11fc5.png)
