### PR TITLE
fix(telegram): adapt reply message

### DIFF
--- a/adapters/telegram/src/bot.ts
+++ b/adapters/telegram/src/bot.ts
@@ -93,14 +93,8 @@ export class TelegramBot<C extends Context = Context, T extends TelegramBot.Conf
     session.timestamp = message.date * 1000
     const segments: segment[] = []
     if (message.reply_to_message) {
-      const replayText = message.reply_to_message.text || message.reply_to_message.caption
-      const parsedReply = parseText(replayText, message.reply_to_message.entities || [])
-      session.quote = {
-        messageId: message.reply_to_message.message_id.toString(),
-        author: adaptUser(message.reply_to_message.from),
-        content: replayText ? parsedReply.join('') : undefined,
-      }
-      segments.push(segment('quote', { id: message.reply_to_message.message_id, channelId: message.reply_to_message.chat.id }))
+      session.quote = {}
+      await this.adaptMessage(message.reply_to_message, session.quote as Session)
     }
     if (message.location) {
       segments.push(segment('location', { lat: message.location.latitude, lon: message.location.longitude }))


### PR DESCRIPTION
adapter 接收消息时不应该将 `quote` 加入 `segments` 中。

改用 `adaptMessage` 的原因是，原本这里只做了很简单的消息处理，并没有处理图片等更复杂的内容。

另外这里的 `as Session`，是否将 `adaptMessage` 的参数 `session` 的类型更改为 `Message` 更好呢，不过这样的话需要修改这个函数中大量出现的 `session`，不知道 @shigma 的意见如何。