### PR TITLE
feat(jsx): add @satorijs/jsx

### DIFF
--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@satorijs/jsx",
+  "description": "Element JSX support",
+  "version": "1.0.0",
+  "main": "lib/index.cjs",
+  "module": "lib/index.mjs",
+  "typings": "lib/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./lib/index.cjs",
+      "import": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
+    },
+    "./jsx-runtime": {
+      "require": "./lib/index.cjs",
+      "import": "./lib/index.mjs",
+      "types": "./lib/index.d.ts"
+    }
+  },
+  "files": [
+    "lib"
+  ],
+  "author": "Shigma <shigma10826@gmail.com>",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/satorijs/satori.git",
+    "directory": "packages/message"
+  },
+  "bugs": {
+    "url": "https://github.com/satorijs/satori/issues"
+  },
+  "homepage": "https://satori.js.org/",
+  "keywords": [
+    "satori",
+    "element",
+    "segment",
+    "component",
+    "message",
+    "utilities"
+  ],
+  "dependencies": {
+    "cosmokit": "^1.3.3",
+    "@satorijs/element": "^2.0.0"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.typing.json"
+  }
+}

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -42,8 +42,5 @@
   "dependencies": {
     "cosmokit": "^1.3.3",
     "@satorijs/element": "^2.0.0"
-  },
-  "scripts": {
-    "build": "tsc -p tsconfig.typing.json"
   }
 }

--- a/packages/jsx/src/index.ts
+++ b/packages/jsx/src/index.ts
@@ -1,0 +1,16 @@
+import segment from '@satorijs/element'
+import { Dict } from 'cosmokit'
+
+export function jsx(
+  type: string,
+  attrs: Dict<any>,
+  ...children: segment.Fragment[]
+) {
+  return segment(type, attrs, ...children)
+}
+
+declare global {
+  namespace JSX {
+    interface Element extends segment {}
+  }
+}

--- a/packages/jsx/tsconfig.json
+++ b/packages/jsx/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "lib",
+  },
+  "include": [
+    "src"
+  ]
+}


### PR DESCRIPTION
Now it supports .tsx in plugins, for element definitions.

For plugins, the following should be configured to use tsx in plugins.

1. install `@satorijs/jsx`
2. in `tsconfig.json`, add the following, and configure the include path to make it include `.tsx` files.
```json
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "@satorijs/jsx",
    "moduleResolution": "Node16"
  }
}
```
