### PR TITLE
feat: add `session.fid` as user context identifier

### DIFF
--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -62,6 +62,10 @@ export class Session {
   get cid() {
     return `${this.platform}:${this.channelId}`
   }
+  
+  get bid() {
+    return `${this.platform}:${this.channelId}:${this.userId}`
+  }
 
   get sid() {
     return `${this.platform}:${this.selfId}`

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -63,7 +63,7 @@ export class Session {
     return `${this.platform}:${this.channelId}`
   }
   
-  get bid() {
+  get fid() {
     return `${this.platform}:${this.channelId}:${this.userId}`
   }
 


### PR DESCRIPTION
## 内容描述
在`Session`中加入了一个`fid`（full id）。类似于`cid`、`gid`以及`sid`。

## 希望解决的问题

作用是创建一个与平台，群组，用户都相关的标识符。可以做到不同平台，可以做到同一个平台，同一个用户在不同群组中也有不同的id。

对一些服务（比如[chatgpt-bot](https://github.com/koishijs/chatgpt-bot)的上下文）很有用。

## 内容格式

```ts
get fid() {
  return `${this.platform}:${this.channelId}:${this.userId}`
}
```