### PR TITLE
fix(discord): 修复重连后无法接收消息的问题

### DIFF
--- a/adapters/discord/src/ws.ts
+++ b/adapters/discord/src/ws.ts
@@ -78,6 +78,11 @@ export class WsClient extends Adapter.WsClient<DiscordBot> {
         const session = await adaptSession(this.bot, parsed)
         if (session) this.bot.dispatch(session)
       }
+      
+      if (parsed.op === GatewayOpcode.INVALID_SESSION) {
+        this._sessionId = ''
+        this.bot.socket.close()
+      }
     })
 
     this.bot.socket.on('close', () => {


### PR DESCRIPTION
https://discord.com/developers/docs/topics/gateway#resuming

"It's possible your app won't reconnect in time to Resume, in which case it will receive an [Invalid Session (opcode 9)](https://discord.com/developers/docs/topics/gateway-events#invalid-session) event. If the d field is set to false (which is most of the time), your app should disconnect. After disconnect, your app should create a new connection with your cached URL from the [Get Gateway](https://discord.com/developers/docs/topics/gateway#get-gateway) or the [Get Gateway Bot](https://discord.com/developers/docs/topics/gateway#get-gateway-bot) endpoint, then send an [Identify (opcode 2)](https://discord.com/developers/docs/topics/gateway-events#identify) event."