### PR TITLE
fix: cannot send gif

### DIFF
--- a/adapters/telegram/src/message.ts
+++ b/adapters/telegram/src/message.ts
@@ -10,8 +10,16 @@ type AssetType = 'photo' | 'audio' | 'document' | 'video' | 'animation'
 async function appendAsset(bot: TelegramBot, form: FormData, element: segment): Promise<AssetType> {
   let assetType: AssetType
   const { filename, data, mime } = await bot.ctx.http.file(element.attrs.url)
+  let assetName: string = element.attrs.file || filename
   if (element.type === 'image') {
     assetType = mime === 'image/gif' ? 'animation' : 'photo'
+    if(!assetName.includes('.')){
+      // lack of extension
+      assetName += `.${mime.split('/')[1]}`
+    }else if(assetName.includes('.image')){
+      // .image cannot be displayed
+      assetName = assetName.replace('.image', `.${mime.split('/')[1]}`)
+    }
   } else if (element.type === 'file') {
     assetType = 'document'
   } else {
@@ -21,7 +29,7 @@ async function appendAsset(bot: TelegramBot, form: FormData, element: segment): 
   const value = process.env.KOISHI_ENV === 'browser'
     ? new Blob([data], { type: mime })
     : Buffer.from(data)
-  form.append(assetType, value, filename)
+  form.append(assetType, value, assetName)
   return assetType
 }
 

--- a/adapters/telegram/src/message.ts
+++ b/adapters/telegram/src/message.ts
@@ -14,7 +14,7 @@ async function appendAsset(bot: TelegramBot, form: FormData, element: segment): 
   if (element.type === 'image') {
     assetType = mime === 'image/gif' ? 'animation' : 'photo'
     if(!assetName.includes('.')){
-      // lack of extension
+      // missing extension
       assetName += `.${mime.split('/')[1]}`
     }else if(assetName.includes('.image')){
       // .image cannot be displayed


### PR DESCRIPTION
`bot.ctx.http.file(element.attrs.url)` 获取的 filename 有时候不会携带文件扩展名，会导致 Telegram 客户端无法正常显示 GIF。

Fixes koishijs/koishi#1006