### PR TITLE
fix(kook): added `extra` field for `kook/message-btn-click`

### DIFF
--- a/adapters/kook/src/utils.ts
+++ b/adapters/kook/src/utils.ts
@@ -213,6 +213,7 @@ export function adaptSession(bot: Bot, input: any) {
         session.userId = body.user_id
         session.content = body.value
         session.targetId = body.target_id
+        session.extra = body
         break
       default: return
     }


### PR DESCRIPTION
body 中的 user_info 字段需要传过来，将 body 放入 extra 中