### PR TITLE
fix(core): support xml body

### DIFF
--- a/packages/satori/src/router.ts
+++ b/packages/satori/src/router.ts
@@ -62,7 +62,9 @@ export class Router extends KoaRouter {
 
     // create server
     const koa = new Koa()
-    koa.use(require('koa-bodyparser')())
+    koa.use(require('koa-bodyparser')({
+      enableTypes: ['json', 'form', 'xml'],
+    }))
     koa.use(this.routes())
     koa.use(this.allowedMethods())
 


### PR DESCRIPTION
用于 `wecom`, `wechatofficial` ~等~平台的 webhook 传入