### PR TITLE
feat: add `br` and `p` element support and fix `p` behavior

### DIFF
--- a/adapters/dingtalk/src/message.ts
+++ b/adapters/dingtalk/src/message.ts
@@ -98,8 +98,10 @@ export class DingtalkMessageEncoder extends MessageEncoder<DingtalkBot> {
       await this.render(children)
     } else if (type === 'at') {
       this.buffer += `@${attrs.id}`
-    } else if (type === 'p') {
+    } else if (type === 'br') {
       this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
       this.buffer += '\n'
     } else if (type === 'b' || type === 'strong') {

--- a/adapters/dingtalk/src/message.ts
+++ b/adapters/dingtalk/src/message.ts
@@ -103,6 +103,7 @@ export class DingtalkMessageEncoder extends MessageEncoder<DingtalkBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       this.buffer += '\n'
     } else if (type === 'b' || type === 'strong') {
       this.buffer += ` **`

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -192,6 +192,7 @@ export class DiscordMessageEncoder extends MessageEncoder<DiscordBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       this.buffer += '\n'
     } else if (type === 'blockquote') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -187,6 +187,8 @@ export class DiscordMessageEncoder extends MessageEncoder<DiscordBot> {
       } else {
         this.buffer += ` (<${attrs.href}>) `
       }
+    } else if (type === 'br') {
+      this.buffer += '\n'
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)

--- a/adapters/kook/src/message.ts
+++ b/adapters/kook/src/message.ts
@@ -165,9 +165,11 @@ export class KookMessageEncoder extends MessageEncoder<KookBot> {
       this.buffer += `[`
       await this.render(children)
       this.buffer += `](${attrs.href})`
-    } else if (type === 'p') {
-      await this.render(children)
+    } else if (type === 'br') {
       this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
+      await this.render(children)
     } else if (type === 'at') {
       if (attrs.id) {
         this.buffer += `(met)${attrs.id}(met)`

--- a/adapters/kook/src/message.ts
+++ b/adapters/kook/src/message.ts
@@ -170,6 +170,7 @@ export class KookMessageEncoder extends MessageEncoder<KookBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
     } else if (type === 'at') {
       if (attrs.id) {
         this.buffer += `(met)${attrs.id}(met)`

--- a/adapters/lark/src/message.ts
+++ b/adapters/lark/src/message.ts
@@ -147,6 +147,12 @@ export class LarkMessageEncoder extends MessageEncoder<LarkBot> {
         await this.render(children)
         if (attrs.href) this.content += ` (${attrs.href})`
         break
+      case 'p':
+        if (!this.content.endsWith('\n')) this.content += '\n'
+        await this.render(children)
+        break
+      case 'br':
+        this.content += '\n'
       case 'sharp':
         // platform does not support sharp
         break

--- a/adapters/lark/src/message.ts
+++ b/adapters/lark/src/message.ts
@@ -153,6 +153,7 @@ export class LarkMessageEncoder extends MessageEncoder<LarkBot> {
         break
       case 'br':
         this.content += '\n'
+        break
       case 'sharp':
         // platform does not support sharp
         break

--- a/adapters/lark/src/message.ts
+++ b/adapters/lark/src/message.ts
@@ -150,6 +150,7 @@ export class LarkMessageEncoder extends MessageEncoder<LarkBot> {
       case 'p':
         if (!this.content.endsWith('\n')) this.content += '\n'
         await this.render(children)
+        if (!this.content.endsWith('\n')) this.content += '\n'
         break
       case 'br':
         this.content += '\n'

--- a/adapters/line/src/message.ts
+++ b/adapters/line/src/message.ts
@@ -47,6 +47,11 @@ export class LineMessageEncoder extends MessageEncoder<LineBot> {
 
     if (type === 'text') {
       this.buffer += attrs.content
+    } else if (type === 'br') {
+      this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
+      await this.render(children)
     } else if (type === 'image' && attrs.url) {
       await this.insertBlock()
       this.blocks.push({

--- a/adapters/line/src/message.ts
+++ b/adapters/line/src/message.ts
@@ -52,6 +52,7 @@ export class LineMessageEncoder extends MessageEncoder<LineBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
     } else if (type === 'image' && attrs.url) {
       await this.insertBlock()
       this.blocks.push({

--- a/adapters/mail/src/message.ts
+++ b/adapters/mail/src/message.ts
@@ -39,7 +39,9 @@ export class MailMessageEncoder extends MessageEncoder<MailBot> {
     const { type, attrs, children } = element
     if (type === 'text') {
       this.buffer += attrs.content
-    } else if (['b', 'strong', 'i', 'em', 'u', 'ins', 's', 'del', 'p', 'code', 'li', 'ul', 'ol', 'blockquote', 'br'].includes(type)) {
+    } else if (type === 'br') {
+      this.buffer += '<br>'
+    } else if (['b', 'strong', 'i', 'em', 'u', 'ins', 's', 'del', 'p', 'code', 'li', 'ul', 'ol', 'blockquote'].includes(type)) {
       this.buffer += `<${type}>`
       await this.render(children)
       this.buffer += `</${type}>`

--- a/adapters/mail/src/message.ts
+++ b/adapters/mail/src/message.ts
@@ -39,7 +39,7 @@ export class MailMessageEncoder extends MessageEncoder<MailBot> {
     const { type, attrs, children } = element
     if (type === 'text') {
       this.buffer += attrs.content
-    } else if (['b', 'strong', 'i', 'em', 'u', 'ins', 's', 'del', 'p', 'code', 'li', 'ul', 'ol', 'blockquote'].includes(type)) {
+    } else if (['b', 'strong', 'i', 'em', 'u', 'ins', 's', 'del', 'p', 'code', 'li', 'ul', 'ol', 'blockquote', 'br'].includes(type)) {
       this.buffer += `<${type}>`
       await this.render(children)
       this.buffer += `</${type}>`

--- a/adapters/matrix/src/message.ts
+++ b/adapters/matrix/src/message.ts
@@ -72,6 +72,7 @@ export class MatrixMessageEncoder extends MessageEncoder<MatrixBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
     } else if (type === 'at') {
       if (attrs.id) {
         this.buffer += ` @${attrs.id} `

--- a/adapters/matrix/src/message.ts
+++ b/adapters/matrix/src/message.ts
@@ -67,9 +67,11 @@ export class MatrixMessageEncoder extends MessageEncoder<MatrixBot> {
       this.buffer += '['
       await this.render(children)
       this.buffer += `](${attrs.href})`
-    } else if (type === 'p') {
-      await this.render(children)
+    } else if (type === 'br') {
       this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
+      await this.render(children)
     } else if (type === 'at') {
       if (attrs.id) {
         this.buffer += ` @${attrs.id} `

--- a/adapters/onebot/src/bot/message.ts
+++ b/adapters/onebot/src/bot/message.ts
@@ -89,6 +89,8 @@ export class OneBotMessageEncoder extends MessageEncoder<BaseBot> {
     let { type, attrs, children } = element
     if (type === 'text') {
       this.text(attrs.content)
+    } else if (type === 'br') {
+      this.text('\n')
     } else if (type === 'p') {
       const prev = this.children[this.children.length - 1]
       if (prev?.type === 'text') {

--- a/adapters/qqguild/src/message.ts
+++ b/adapters/qqguild/src/message.ts
@@ -143,6 +143,7 @@ export class QQGuildMessageEncoder extends MessageEncoder<QQGuildBot> {
     } else if (type === 'p') {
       if (!this.content.endsWith('\n')) this.content += '\n'
       await this.render(children)
+      if (!this.content.endsWith('\n')) this.content += '\n'
     } else if (type === 'sharp') {
       this.content += `<#${attrs.id}>`
     } else if (type === 'quote') {

--- a/adapters/qqguild/src/message.ts
+++ b/adapters/qqguild/src/message.ts
@@ -138,6 +138,11 @@ export class QQGuildMessageEncoder extends MessageEncoder<QQGuildBot> {
         default:
           this.content += `<@${attrs.id}>`
       }
+    } else if (type === 'br') {
+      this.content += '\n'
+    } else if (type === 'p') {
+      if (!this.content.endsWith('\n')) this.content += '\n'
+      await this.render(children)
     } else if (type === 'sharp') {
       this.content += `<#${attrs.id}>`
     } else if (type === 'quote') {

--- a/adapters/slack/src/message.ts
+++ b/adapters/slack/src/message.ts
@@ -106,6 +106,7 @@ export class SlackMessageEncoder extends MessageEncoder<SlackBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += `\n`
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += `\n`
     } else if (type === 'face') {
       this.buffer += `:${attrs.id}:`
     } else if (type === 'author') {

--- a/adapters/slack/src/message.ts
+++ b/adapters/slack/src/message.ts
@@ -101,8 +101,10 @@ export class SlackMessageEncoder extends MessageEncoder<SlackBot> {
       this.buffer += `>`
     } else if (type === 'quote') {
       this.thread_ts = attrs.id
+    } else if (type === 'br') {
+      this.buffer += '\n'
     } else if (type === 'p') {
-      this.buffer += `\n`
+      if (!this.buffer.endsWith('\n')) this.buffer += `\n`
       await this.render(children)
     } else if (type === 'face') {
       this.buffer += `:${attrs.id}:`

--- a/adapters/telegram/src/message.ts
+++ b/adapters/telegram/src/message.ts
@@ -89,6 +89,7 @@ export class TelegramMessageEncoder extends MessageEncoder<TelegramBot> {
     } else if (type === 'p') {
       if (!this.payload.caption.endsWith('\n')) this.payload.caption += '\n'
       await this.render(children)
+      if (!this.payload.caption.endsWith('\n')) this.payload.caption += '\n'
     } else if (supportedElements.includes(type)) {
       this.payload.caption += element.toString()
     } else if (type === 'spl') {

--- a/adapters/telegram/src/message.ts
+++ b/adapters/telegram/src/message.ts
@@ -84,9 +84,11 @@ export class TelegramMessageEncoder extends MessageEncoder<TelegramBot> {
     const { type, attrs, children } = element
     if (type === 'text') {
       this.payload.caption += h.escape(attrs.content)
-    } else if (type === 'p') {
-      await this.render(children)
+    } else if (type === 'br') {
       this.payload.caption += '\n'
+    } else if (type === 'p') {
+      if (!this.payload.caption.endsWith('\n')) this.payload.caption += '\n'
+      await this.render(children)
     } else if (supportedElements.includes(type)) {
       this.payload.caption += element.toString()
     } else if (type === 'spl') {

--- a/adapters/wechat-official/src/message.ts
+++ b/adapters/wechat-official/src/message.ts
@@ -142,6 +142,7 @@ export class WechatOfficialMessageEncoder extends MessageEncoder<WechatOfficialB
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
     } else if (type === 'image' || type === 'audio' || type === 'video') {
       await this.flushMedia(element)
     } else if (type === 'message') {

--- a/adapters/wechat-official/src/message.ts
+++ b/adapters/wechat-official/src/message.ts
@@ -137,9 +137,11 @@ export class WechatOfficialMessageEncoder extends MessageEncoder<WechatOfficialB
     const { type, attrs, children } = element
     if (type === 'text') {
       this.buffer += attrs.content
-    } else if (type === 'p') {
-      await this.render(children)
+    } else if (type === 'br') {
       this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
+      await this.render(children)
     } else if (type === 'image' || type === 'audio' || type === 'video') {
       await this.flushMedia(element)
     } else if (type === 'message') {

--- a/adapters/wecom/src/message.ts
+++ b/adapters/wecom/src/message.ts
@@ -97,6 +97,7 @@ export class WecomMessageEncoder extends MessageEncoder<WecomBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
     } else if (type === 'image' || type === 'audio' || type === 'video' || type === 'file') {
       await this.flushMedia(element)
     } else if (type === 'a' && attrs.href) {

--- a/adapters/wecom/src/message.ts
+++ b/adapters/wecom/src/message.ts
@@ -92,9 +92,11 @@ export class WecomMessageEncoder extends MessageEncoder<WecomBot> {
     const { type, attrs, children } = element
     if (type === 'text') {
       this.buffer += attrs.content
-    } else if (type === 'p') {
-      await this.render(children)
+    } else if (type === 'br') {
       this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
+      await this.render(children)
     } else if (type === 'image' || type === 'audio' || type === 'video' || type === 'file') {
       await this.flushMedia(element)
     } else if (type === 'a' && attrs.href) {

--- a/adapters/whatsapp/src/message.ts
+++ b/adapters/whatsapp/src/message.ts
@@ -119,6 +119,7 @@ export class WhatsAppMessageEncoder extends MessageEncoder<WhatsAppBot> {
     } else if (type === 'p') {
       if (!this.buffer.endsWith('\n')) this.buffer += '\n'
       await this.render(children)
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
     } else if (type === 'a') {
       await this.render(children)
       this.buffer += ` (${attrs.href}) `

--- a/adapters/whatsapp/src/message.ts
+++ b/adapters/whatsapp/src/message.ts
@@ -114,9 +114,11 @@ export class WhatsAppMessageEncoder extends MessageEncoder<WhatsAppBot> {
       } else {
         await this.sendMessage('sticker', { id: attrs.id })
       }
-    } else if (type === 'p') {
-      await this.render(children)
+    } else if (type === 'br') {
       this.buffer += '\n'
+    } else if (type === 'p') {
+      if (!this.buffer.endsWith('\n')) this.buffer += '\n'
+      await this.render(children)
     } else if (type === 'a') {
       await this.render(children)
       this.buffer += ` (${attrs.href}) `


### PR DESCRIPTION
### Add `br` element support for:
- All adapter
### Add `br` and `p` element support for:
- lark
- line
- qqguild
### Fix `p` behavior
#### Now behavior 
Check for previous `\n`. If no, then append `\n`.
#### Previous behavior
No check for previous `\n`, append `\n` immediately.
#### For following these adapter:
- dingtalk
- kook
- matrix
- slack
- telegram
- wechat-offical
- wecom
- whatsapp

close koishijs/koishi#1185