### PR TITLE
feat(qq): support `passive` element

### DIFF
--- a/adapters/qq/src/message.ts
+++ b/adapters/qq/src/message.ts
@@ -110,7 +110,6 @@ export class QQGuildMessageEncoder<C extends Context = Context> extends MessageE
     this.file = null
     this.filename = null
     this.fileUrl = null
-    this.passiveId = null
     this.resource = null
     this.retry = false
   }
@@ -265,8 +264,6 @@ export class QQMessageEncoder<C extends Context = Context> extends MessageEncode
     // this.results.push(session.event.message)
     // session.app.emit(session, 'send', session)
     this.content = ''
-    this.passiveId = null
-    this.passiveSeq = null
     this.attachedFile = null
     this.rows = []
   }

--- a/adapters/qq/src/message.ts
+++ b/adapters/qq/src/message.ts
@@ -14,6 +14,7 @@ export class QQGuildMessageEncoder<C extends Context = Context> extends MessageE
   private file: Buffer
   private filename: string
   fileUrl: string
+  private passiveId: string
   reference: string
   private retry = false
   private resource: Dict
@@ -31,6 +32,7 @@ export class QQGuildMessageEncoder<C extends Context = Context> extends MessageE
     if (this.options?.session && (Date.now() - this.options?.session?.timestamp) > MSG_TIMEOUT) {
       msg_id = null
     }
+    if (this.passiveId) msg_id = this.passiveId
 
     let r: Partial<QQ.Message.Response>
     this.bot.logger.debug('use form data %s', useFormData)
@@ -165,6 +167,8 @@ export class QQGuildMessageEncoder<C extends Context = Context> extends MessageE
     } else if (type === 'quote') {
       this.reference = attrs.id
       await this.flush()
+    } else if (type === 'passive') {
+      this.passiveId = attrs.id
     } else if (type === 'image' && attrs.url) {
       await this.flush()
       await this.resolveFile(attrs)
@@ -183,6 +187,8 @@ const MSG_TIMEOUT = 5 * 60 * 1000 - 2000// 5 mins
 
 export class QQMessageEncoder<C extends Context = Context> extends MessageEncoder<C, QQBot<C>> {
   private content: string = ''
+  private passiveId: string
+  private passiveSeq: number
   private useMarkdown = false
   private rows: QQ.Button[][] = []
   private attachedFile: QQ.Message.File.Response
@@ -197,6 +203,8 @@ export class QQMessageEncoder<C extends Context = Context> extends MessageEncode
       msg_id = this.options.session.messageId
       msg_seq = ++this.options.session['seq']
     }
+    if (this.passiveId) msg_id = this.passiveId
+    if (this.passiveSeq) msg_seq = this.passiveSeq
     const data: QQ.Message.Request = {
       content: this.content,
       msg_type: QQ.Message.Type.TEXT,
@@ -361,6 +369,9 @@ export class QQMessageEncoder<C extends Context = Context> extends MessageEncode
     const { type, attrs, children } = element
     if (type === 'text') {
       this.content += attrs.content
+    } else if (type === 'passive') {
+      this.passiveId = attrs.id
+      this.passiveSeq = Number(attrs.seq)
     } else if (type === 'image' && attrs.url) {
       await this.flush()
       const data = await this.sendFile(type, attrs)

--- a/adapters/qq/src/message.ts
+++ b/adapters/qq/src/message.ts
@@ -110,6 +110,7 @@ export class QQGuildMessageEncoder<C extends Context = Context> extends MessageE
     this.file = null
     this.filename = null
     this.fileUrl = null
+    this.passiveId = null
     this.resource = null
     this.retry = false
   }
@@ -264,6 +265,8 @@ export class QQMessageEncoder<C extends Context = Context> extends MessageEncode
     // this.results.push(session.event.message)
     // session.app.emit(session, 'send', session)
     this.content = ''
+    this.passiveId = null
+    this.passiveSeq = null
     this.attachedFile = null
     this.rows = []
   }


### PR DESCRIPTION
为 QQ 适配器引入 `passive` 元素，属于元信息元素，定义如下：

### 被动消息 (passive)

| 属性 | 类型 | 范围 | 描述 |
| --- | --- | --- | --- |
| id | string | 发 | 关联的消息 |
| seq | number? | 发 | 消息的序号，同 id 同 seq 的被动消息只会被发送一次 |
