### PR TITLE
fix(qq): fix send group msg using `bot.sendMessage()`

### DIFF
--- a/adapters/qq/src/message.ts
+++ b/adapters/qq/src/message.ts
@@ -232,7 +232,7 @@ export class QQMessageEncoder<C extends Context = Context> extends MessageEncode
         session.messageId = msg_id
       } else {
         // FIXME: missing message id
-        const resp = await this.bot.internal.sendMessage(this.guildId, data)
+        const resp = await this.bot.internal.sendMessage(this.session.channelId, data)
         if (resp.msg !== 'success') {
           this.bot.logger.warn(resp)
         }


### PR DESCRIPTION
发送消息的行为永远在频道发生，因此请永远使用 channelId 而非 guildId。
