### PR TITLE
fix(core): default to group when no `options.session`

### DIFF
--- a/packages/core/src/message.ts
+++ b/packages/core/src/message.ts
@@ -31,7 +31,7 @@ export abstract class MessageEncoder<C extends Context = Context, B extends Bot<
   }
 
   async send(content: h.Fragment) {
-    const isDirect = this.options.session?.isDirect ?? !this.guildId
+    const isDirect = this.options.session?.isDirect
     this.session = this.bot.session({
       type: 'send',
       channel: { id: this.channelId, type: isDirect ? Channel.Type.DIRECT : Channel.Type.TEXT },


### PR DESCRIPTION
对于 `createMessage` API，判断在私聊还是群聊中发送是适配器的职责。在判断出私聊还是群聊后，适配器需要在 `MessageEncoder` 的 `prepare()` 方法中做如下五件事：

1. 设置 `this.session.isDirect`，该值在被适配器设置之前始终为默认值
1. `this.session.channel.type = this.session.isDirect ? Channel.Type.DIRECT : Channel.Type.TEXT`
1. `this.session.subtype = this.session.isDirect ? 'private' : 'group'`
1. 如果 Bot 对应的平台为单层架构（无 Guild 概念），则 `if (!this.session.isDirect) this.guildId = this.channelId`
1. 修正所有 `flush()` 及同类方法中的实际消息发送逻辑，使其基于 `this.session.isDirect` 判断需要调用的 API

[adapter-onebot#8](https://github.com/koishijs/koishi-plugin-adapter-onebot/pull/8) 是上面修改的一个完美示范。

---

对于本 PR，一般地，若 `createMessage` 请求没有来源 session，且适配器也不打算进行上述三项设置的情况下，我们认为此时应当默认发送群聊消息。这一结论根据目前的用户群体在私聊和群聊中使用该 API 的比例得出。本 PR 规范了这一行为。

本 PR 是一个中间改动。在所有适配器均实现了上面所述的判断逻辑后，本 PR 中 `send()` 方法中 `isDirect` 相关部分将会全部失效，届时将可以直接删除相关行。
