### PR TITLE
feat(lark): add more api, correct function name

### DIFF
--- a/adapters/lark/src/bot.ts
+++ b/adapters/lark/src/bot.ts
@@ -87,7 +87,7 @@ export class LarkBot<C extends Context = Context> extends Bot<C, LarkBot.Config>
   }
 
   async getUser(userId: string, guildId?: string) {
-    const data = await this.internal.getUserInfo(userId)
+    const data = await this.internal.getContactUser(userId)
     return Utils.decodeUser(data.data)
   }
 

--- a/adapters/lark/src/types/message/index.ts
+++ b/adapters/lark/src/types/message/index.ts
@@ -205,6 +205,17 @@ declare module '../internal' {
     getMessage(message_id: string): Promise<BaseResponse & { data: Message }>
     /** @see https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/delete */
     deleteMessage(message_id: string): Promise<BaseResponse>
+    /** @see https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/forward */
+    forwardMessage(
+      message_id: string,
+      receive_id_type: Lark.ReceiveIdType,
+      data: { receive_id: string },
+    ): Promise<BaseResponse & { data: Message }>
+    /** @see https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/merge_forward */
+    mergeForwardMessage(
+      receive_id_type: Lark.ReceiveIdType,
+      data: { receive_id: string, message_id_list: string[] },
+    ): Promise<BaseResponse & { data: { message: Message, invalid_message_id_list: string[] }}>
     /** @see https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/read_users */
     getMessageReadUsers(message_id: string, params: Pagination<{ user_id_type: Lark.UserIdType }>): Promise<BaseResponse & { data: Paginated<ReadUser> }>
     /** @see https://open.larksuite.com/document/server-docs/im-v1/message/list */
@@ -229,5 +240,11 @@ Internal.define({
   },
   '/im/v1/messages/{message_id}/read_users': {
     GET: 'getMessageReadUsers',
+  },
+  '/im/v1/messages/{message_id}/forward?receive_id_type={receive_id_type}': {
+    POST: 'forwardMessage',
+  },
+  '/im/v1/messages/merge_forward?receive_id_type={receive_id_type}': {
+    POST: 'mergeForwardMessage',
   },
 })

--- a/adapters/lark/src/types/message/index.ts
+++ b/adapters/lark/src/types/message/index.ts
@@ -214,8 +214,8 @@ declare module '../internal' {
     /** @see https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/merge_forward */
     mergeForwardMessage(
       receive_id_type: Lark.ReceiveIdType,
-      data: { receive_id: string, message_id_list: string[] },
-    ): Promise<BaseResponse & { data: { message: Message, invalid_message_id_list: string[] }}>
+      data: { receive_id: string; message_id_list: string[] },
+    ): Promise<BaseResponse & { data: { message: Message; invalid_message_id_list: string[] }}>
     /** @see https://open.larksuite.com/document/uAjLw4CM/ukTMukTMukTM/reference/im-v1/message/read_users */
     getMessageReadUsers(message_id: string, params: Pagination<{ user_id_type: Lark.UserIdType }>): Promise<BaseResponse & { data: Paginated<ReadUser> }>
     /** @see https://open.larksuite.com/document/server-docs/im-v1/message/list */

--- a/adapters/lark/src/types/user.ts
+++ b/adapters/lark/src/types/user.ts
@@ -80,12 +80,12 @@ export interface GuildMember {
 declare module './internal' {
   export interface Internal {
     /** @see https://open.larksuite.com/document/server-docs/contact-v3/user/get */
-    getUserInfo(user_id: string, user_id_type?: Lark.UserIdType, department_id_type?: Lark.DepartmentIdType): Promise<BaseResponse & { data: Lark.User }>
+    getContactUser(user_id: string, user_id_type?: Lark.UserIdType, department_id_type?: Lark.DepartmentIdType): Promise<BaseResponse & { data: Lark.User }>
   }
 }
 
 Internal.define({
   'contact/v3/users/{user_id}': {
-    GET: 'getUserInfo',
+    GET: 'getContactUser',
   },
 })


### PR DESCRIPTION
This commit add APIs for "forwarding messages" and "merging and forwarding messages", also changing the original `getUserInfo` function to the consist one `getContactUser`

Fix #207