### PR TITLE
fix(discord): confuse of `required` argument

### DIFF
--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -384,7 +384,7 @@ export function encodeCommandOptions(cmd: Universal.Command): Discord.Applicatio
         ...encodeDescription(option),
         name: option.name.toLowerCase(),
         type: types[option.type] ?? types.text,
-        required: option.required ?? false,
+        required: false,
         min_value: option.type === 'posint' ? 1 : undefined,
       })
     }


### PR DESCRIPTION
* I think the `required` argument of options in `Universal.Command` denotes whether a *value* should be present,
* however, the `required` argument in Discord denotes whether *this option* should be present.