### PR TITLE
fix(telegram): Invalid URL when enabled files.local

### DIFF
--- a/adapters/telegram/src/bot.ts
+++ b/adapters/telegram/src/bot.ts
@@ -144,7 +144,7 @@ export class TelegramBot<C extends Context = Context, T extends TelegramBot.Conf
 
   async $getFile(filePath: string) {
     if (this.local) {
-      return await this.ctx.http.file(filePath)
+      return await this.ctx.http.file(`file://${filePath}`)
     } else {
       return await this.file.file(`/${filePath}`)
     }

--- a/adapters/telegram/src/bot.ts
+++ b/adapters/telegram/src/bot.ts
@@ -1,4 +1,5 @@
 import { Binary, Bot, Context, Dict, h, HTTP, Schema, Time, Universal } from '@satorijs/core'
+import { pathToFileURL } from 'url'
 import * as Telegram from './types'
 import { decodeGuildMember, decodeUser } from './utils'
 import { TelegramMessageEncoder } from './message'
@@ -144,7 +145,7 @@ export class TelegramBot<C extends Context = Context, T extends TelegramBot.Conf
 
   async $getFile(filePath: string) {
     if (this.local) {
-      return await this.ctx.http.file(`file://${filePath}`)
+      return await this.ctx.http.file(pathToFileURL(filePath).href)
     } else {
       return await this.file.file(`/${filePath}`)
     }


### PR DESCRIPTION
I run [telegram-bot-api](https://github.com/tdlib/telegram-bot-api) with `--local` argument and enable `files.local` config in Koishi. When I use any API that returns a file (e.g. `getUser` will return user's avatar), I will get a `TypeError: Invalid URL` error like this.

```log
1000|2|2024-05-29 13:20:18 [W] telegram get file error TypeError: Invalid URL: /stor/opt/bot/telegram/***/profile_photos/file_52.jpg at Proxy.resolveURL (/home/su226/.koishi/data/instances/default/node_modules/@cordisjs/plugin-http/lib/index.cjs:250:13) at [cordis.invoke] (/home/su226/.koishi/data/instances/default/node_modules/@cordisjs/plugin-http/lib/index.cjs:278:22) at applyTraceable (/home/su226/.koishi/data/instances/default/node_modules/@cordisjs/core/lib/index.cjs:263:) at Object.apply (/home/su226/.koishi/data/instances/default/node_modules/@cordisjs/core/lib/index.cjs:254:14) at Proxy.file (/home/su226/.koishi/data/instances/default/node_modules/@cordisjs/plugin-http/lib/index.cjs:404:59)     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) at async Proxy.$getFile (/home/su226/.koishi/data/instances/default/node_modules/@satorijs/adapter-telegram/lib/index.cjs:941:14) at async Proxy.$getFileFromPath (/home/su226/.koishi/data/instances/default/node_modules/@satorijs/adapter-telegram/lib/index.cjs:958:26) at async Proxy.$getFileFromId (/home/su226/.koishi/data/instances/default/node_modules/@satorijs/adapter-telegram/lib/index.cjs:949:14) at async Proxy.getUser (/home/su226/.koishi/data/instances/default/node_modules/@satorijs/adapter-telegram/lib/index.cjs:982:21)
```

*No any `\n` in the log as above. `***` in the path is my bot token.*

The PR fixes this, tested on Windows and Linux.