### PR TITLE
feat(discord): support sticker elements

### DIFF
--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -99,7 +99,9 @@ export async function decodeMessage(
       id: s.id,
       format_type: s.format_type,
       name: s.name,
-    })).join('')
+    }, [
+      h.image(`https://media.discordapp.net/stickers/${s.id}.webp?size=160`),
+    ])).join('')
   }
 
   // embed 的 update event 太阴间了 只有 id embeds channel_id guild_id 四个成员

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -94,6 +94,14 @@ export async function decodeMessage(
       })
   }
 
+  if (data.sticker_items) {
+    message.content += data.sticker_items.map(s => h('sticker', {
+      id: s.id,
+      format_type: s.format_type,
+      name: s.name,
+    })).join('')
+  }
+
   // embed 的 update event 太阴间了 只有 id embeds channel_id guild_id 四个成员
   if (data.attachments?.length) {
     if (!/\s$/.test(message.content)) message.content += ' '


### PR DESCRIPTION
This PR implement adapting sticker items into following element
```tsx
<sticker id="id" format_type="format_type" name="name">
  <img src="https://media.discordapp.net/stickers/${s.id}.webp?size=160"/>
</sticker>
```