### PR TITLE
feat(discord): add missing global_name field

### DIFF
--- a/adapters/discord/src/types/user.ts
+++ b/adapters/discord/src/types/user.ts
@@ -8,6 +8,8 @@ export interface User {
   username: string
   /** the user's 4-digit discord-tag */
   discriminator: string
+  /** the user's display name, if it is set. For bots, this is the application name */
+  global_name?: string
   /** the user's avatar hash */
   avatar?: string
   /** whether the user belongs to an OAuth2 application */
@@ -106,7 +108,7 @@ export enum VisibilityType {
   EVERYONE = 1,
 }
 
-export interface UserUpdateEvent extends User {}
+export interface UserUpdateEvent extends User { }
 
 declare module './gateway' {
   interface GatewayEvents {

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -16,6 +16,7 @@ export const sanitizeCode = (val: string) => val.replace(/(?<=`)(?=`)/g, '\u200b
 
 export const decodeUser = (user: Discord.User): Universal.User => ({
   id: user.id,
+  nick: user.global_name,
   name: user.username,
   userId: user.id,
   avatar: user.avatar && `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.png`,


### PR DESCRIPTION
This PR add missing global_name field definition of Discord User and fill it into Universal User's nick field.