### PR TITLE
fix(qq): integrate new audit structure in sending message

### DIFF
--- a/adapters/qq/src/internal/group.ts
+++ b/adapters/qq/src/internal/group.ts
@@ -6,18 +6,14 @@ declare module './internal' {
     sendMessage(channel_id: string, data: QQ.Message.Request): Promise<{
       id: string
       timestamp: string
-    } & {
-      code: number
-      message: string
-      data: any
+      audit_id?: string
+      audit_tips?: string
     }>
     sendPrivateMessage(openid: string, data: QQ.Message.Request): Promise<{
       id: string
       timestamp: string
-    } & {
-      code: number
-      message: string
-      data: any
+      audit_id?: string
+      audit_tips?: string
     }>
     sendFilePrivate(openid: string, data: QQ.Message.File.Request): Promise<any>
     sendFileGuild(group_openid: string, data: QQ.Message.File.Request): Promise<any>

--- a/adapters/qq/src/message.ts
+++ b/adapters/qq/src/message.ts
@@ -248,16 +248,16 @@ export class QQMessageEncoder<C extends Context = Context> extends MessageEncode
         const resp = this.session.isDirect
           ? await this.bot.internal.sendPrivateMessage(this.session.channelId, data)
           : await this.bot.internal.sendMessage(this.session.channelId, data)
-        if (resp.id) {
+        if (resp.id && !resp.audit_id) {
           session.messageId = resp.id
           session.timestamp = new Date(resp.timestamp).valueOf()
           session.channelId = this.session.channelId
           session.guildId = this.session.guildId
           session.app.emit(session, 'send', session)
           this.results.push(session.event.message)
-        } else if (resp.code === 304023 && this.bot.config.intents & QQ.Intents.MESSAGE_AUDIT) {
+        } else if (resp.audit_id && this.bot.config.intents & QQ.Intents.MESSAGE_AUDIT) {
           try {
-            const auditData: QQ.MessageAudited = await this.audit(resp.data.message_audit.audit_id)
+            const auditData: QQ.MessageAudited = await this.audit(resp.audit_id)
             session.messageId = auditData.message_id
             session.app.emit(session, 'send', session)
             this.results.push(session.event.message)


### PR DESCRIPTION
Add support for the new data format returned by the QQ platform for proactive message audits.