### PR TITLE
feat(telegram): support code block and enhance code support

### DIFF
--- a/adapters/telegram/src/message.ts
+++ b/adapters/telegram/src/message.ts
@@ -221,8 +221,10 @@ export class TelegramMessageEncoder<C extends Context = Context> extends Message
       await this.render(children)
       this.payload.caption += '</tg-spoiler>'
     } else if (type === 'code') {
+      this.payload.caption += `<code>${h.escape(attrs.content ?? children.toString())}</code>`
+    } else if (type === 'code-block') {
       const { lang } = attrs
-      this.payload.caption += `<code${lang ? ` class="language-${lang}"` : ''}>${h.escape(attrs.content)}</code>`
+      this.payload.caption += `<pre><code${lang ? ` class="language-${lang}"` : ''}>${h.escape(children.toString())}</code></pre>`
     } else if (type === 'at') {
       if (attrs.id) {
         this.payload.caption += `<a href="tg://user?id=${attrs.id}">@${attrs.name || attrs.id}</a>`

--- a/adapters/telegram/src/message.ts
+++ b/adapters/telegram/src/message.ts
@@ -221,10 +221,10 @@ export class TelegramMessageEncoder<C extends Context = Context> extends Message
       await this.render(children)
       this.payload.caption += '</tg-spoiler>'
     } else if (type === 'code') {
-      this.payload.caption += `<code>${h.escape(attrs.content ?? children.toString())}</code>`
+      this.payload.caption += `<code>${attrs.content ? h.escape(attrs.content) : children.toString()}</code>`
     } else if (type === 'code-block') {
       const { lang } = attrs
-      this.payload.caption += `<pre><code${lang ? ` class="language-${lang}"` : ''}>${h.escape(children.toString())}</code></pre>`
+      this.payload.caption += `<pre><code${lang ? ` class="language-${lang}"` : ''}>${children.toString()}</code></pre>`
     } else if (type === 'at') {
       if (attrs.id) {
         this.payload.caption += `<a href="tg://user?id=${attrs.id}">@${attrs.name || attrs.id}</a>`


### PR DESCRIPTION
## This PR implements:
- adapting code block into following element
```<code-block lang=python>import numpy as np\n\nb = 1</code-block>```.
- enhance code element support, now both `<code content="foo"/>` and `<code>foo</code>` are accepted.
- Considering compatibility, `content` attribute takes higher priority as `<code content="foo">bar</code>` will display `foo` in current implementation.

## Example:
```ts
session.send(
      `<code content="foo" /> | <code>bar</code> | <code content="baz">qux</code>
      <br />
      <code content="&&gt;=&lt;&" /> | <code>&&gt;=&lt;&</code>
      <br />
      <code-block>import os, sys\nimport numpy as np\n\na = &quot;&amp;&gt;=&lt;&amp;&quot;</code-block>
      <br />
      Display as plain text:
      <code-block lang="txt">import os, sys\nimport numpy as np\n\na = "&&gt;=&lt;&"</code-block>
      To display code block in telegram:
      <code-block lang="html">&lt;pre&gt;&lt;code class="language-python"&gt;Formatted Python code block&lt;/code&gt;&lt;/pre&gt;</code-block>
      `);
```
![photo_2024-08-13_11-56-24 (2)](https://github.com/user-attachments/assets/104bbf89-9c6b-433e-bed9-a3571a024cab)


## Reference:
[Telegram Bot API](https://core.telegram.org/bots/api#html-style)