### PR TITLE
fix(telegram): No user avatar when using local bot API.

### DIFF
--- a/adapters/telegram/src/bot.ts
+++ b/adapters/telegram/src/bot.ts
@@ -57,7 +57,7 @@ export class TelegramBot<C extends Context = Context, T extends TelegramBot.Conf
     if (config.files.server ?? selfUrl) {
       const route = `/telegram/${this.selfId}`
       this.server = selfUrl + route
-      ctx.get('server').get(route + '/:file+', async ctx => {
+      ctx.get('server').get(route + '/:file(.+)', async ctx => {
         const { data, type } = await this.$getFile(ctx.params.file)
         ctx.set('content-type', type)
         ctx.body = Buffer.from(data)
@@ -177,8 +177,8 @@ export class TelegramBot<C extends Context = Context, T extends TelegramBot.Conf
     if (!avatar) return
     const { file_id } = avatar[avatar.length - 1]
     const file = await this.internal.getFile({ file_id })
-    if (this.server) {
-      user.avatar = `${this.server}/${file.file_path}`
+    if (this.local || this.server) {
+      user.avatar = (await this.$getFileFromPath(file.file_path)).src
     } else {
       const { endpoint } = this.file.config
       user.avatar = `${endpoint}/${file.file_path}`


### PR DESCRIPTION
When enable `files.local` only, return a data URL since browsers won't load `file://` URLs.

When enable both `files.local` and `files.server`, adapter generates a URL like `http://127.0.0.1:5140/telegram/your_bot_id//path_to_local_bot_api/your_bot_token/photos/file_1.jpg`, which was not handled by router as intended, so I fixed the route too. This should also fix other file-related APIs when using both `files.local` and `files.server`.