### PR TITLE
fix(core): return `[]` when blocked by `before-send`

### DIFF
--- a/packages/core/src/message.ts
+++ b/packages/core/src/message.ts
@@ -49,7 +49,7 @@ export abstract class MessageEncoder<C extends Context = Context, B extends Bot<
       btn.attrs.id ||= r
       if (typeof btn.attrs.action === 'function') this.bot.callbacks[btn.attrs.id] = btn.attrs.action
     }
-    if (await this.session.app.serial(this.session, 'before-send', this.session, this.options)) return
+    if (await this.session.app.serial(this.session, 'before-send', this.session, this.options)) return []
     await this.render(this.session.elements)
     await this.flush()
     if (this.errors.length) {


### PR DESCRIPTION
fix #321