### PR TITLE
adapter-telegram: only detect chat type if chat object exists

### DIFF
--- a/adapters/telegram/src/utils.ts
+++ b/adapters/telegram/src/utils.ts
@@ -120,21 +120,23 @@ export async function handleUpdate(update: Telegram.Update, bot: TelegramBot) {
       id: update.callback_query.data,
     }
     const data = update.callback_query.message
-    if (data.chat.type === 'private') {
-      session.event.channel = {
-        id: data.chat.id.toString(),
-        type: Universal.Channel.Type.DIRECT,
-      }
-    } else {
-      session.event.guild = {
-        id: data.chat.id.toString(),
-        name: data.chat.title,
-      }
-      session.event.channel = {
-        id: data.is_topic_message
-          ? data.message_thread_id.toString()
-          : data.chat.id.toString(),
-        type: Universal.Channel.Type.TEXT,
+    if (data) {
+      if (data.chat.type === 'private') {
+        session.event.channel = {
+          id: data.chat.id.toString(),
+          type: Universal.Channel.Type.DIRECT,
+        }
+      } else {
+        session.event.guild = {
+          id: data.chat.id.toString(),
+          name: data.chat.title,
+        }
+        session.event.channel = {
+          id: data.is_topic_message
+            ? data.message_thread_id.toString()
+            : data.chat.id.toString(),
+          type: Universal.Channel.Type.TEXT,
+        }
       }
     }
     await bot.internal.answerCallbackQuery({


### PR DESCRIPTION
When the message is sent by user using inline_query feature with attached button, this callback_query will not include any chat object.