### PR TITLE
adapter-qq: support more fields & methods

### DIFF
--- a/adapters/qq/src/bot/guild.ts
+++ b/adapters/qq/src/bot/guild.ts
@@ -121,7 +121,7 @@ export class QQGuildBot<C extends Context = Context> extends Bot<C> {
 
   async getMessage(channelId: string, messageId: string): Promise<Universal.Message> {
     const r = await this.internal.getMessage(channelId, messageId)
-    return decodeMessage(this, r)
+    return decodeMessage(this, r.message)
   }
 
   async deleteMessage(channelId: string, messageId: string) {

--- a/adapters/qq/src/bot/guild.ts
+++ b/adapters/qq/src/bot/guild.ts
@@ -3,6 +3,7 @@ import { QQBot } from '.'
 import { decodeChannel, decodeGuild, decodeGuildMember, decodeMessage, decodeUser } from '../utils'
 import { GuildInternal } from '../internal'
 import { QQGuildMessageEncoder } from '../message'
+import * as QQ from '../types'
 
 export namespace QQGuildBot {
   export interface Config {
@@ -56,6 +57,23 @@ export class QQGuildBot<C extends Context = Context> extends Bot<C> {
 
   async getChannel(channelId: string): Promise<Universal.Channel> {
     const channel = await this.internal.getChannel(channelId)
+    return decodeChannel(channel)
+  }
+
+  async createChannel(guildId: string, data: Partial<Universal.Channel>) {
+    const channel = await this.internal.createGuildChannel(guildId, {
+      name: data.name,
+      type: data.type === Universal.Channel.Type.TEXT ? QQ.ChannelType.TEXT
+        : data.type === Universal.Channel.Type.CATEGORY ? QQ.ChannelType.GROUP
+          : data.type === Universal.Channel.Type.VOICE ? QQ.ChannelType.VOICE
+            : QQ.ChannelType.TEXT,
+      parent_id: data.parentId,
+      position: data.position,
+      sub_type: 0,
+      private_type: 0,
+      speak_permission: 1,
+      private_user_ids: [],
+    })
     return decodeChannel(channel)
   }
 

--- a/adapters/qq/src/bot/index.ts
+++ b/adapters/qq/src/bot/index.ts
@@ -5,6 +5,7 @@ import { QQGuildBot } from './guild'
 import { QQMessageEncoder } from '../message'
 import { GroupInternal } from '../internal'
 import { HttpServer } from '../http'
+import { decodeUser } from '../utils'
 
 interface GetAppAccessTokenResult {
   access_token: string
@@ -54,9 +55,7 @@ export class QQBot<C extends Context = Context, T extends QQBot.Config = QQBot.C
 
   async initialize() {
     const user = await this.guildBot.internal.getMe()
-    Object.assign(this.user, user)
-    this.user.name = user.username
-    this.user.isBot = true
+    Object.assign(this.user, decodeUser(user))
   }
 
   async stop() {

--- a/adapters/qq/src/internal/guild.ts
+++ b/adapters/qq/src/internal/guild.ts
@@ -63,7 +63,7 @@ declare module './internal' {
       add: string
       remove: string
     }): Promise<void>
-    getMessage(channelId: string, messageId: string): Promise<QQ.Message>
+    getMessage(channelId: string, messageId: string): Promise<{ message: QQ.Message }>
     sendMessage(channelId: string, data: QQ.Message.ChannelRequest): Promise<QQ.Message>
     sendDM(guildId: string, data: QQ.Message.ChannelRequest): Promise<QQ.Message>
     deleteMessage(channelId: string, messageId: string, params?: {

--- a/adapters/qq/src/utils.ts
+++ b/adapters/qq/src/utils.ts
@@ -5,13 +5,18 @@ import { QQBot } from './bot'
 export const decodeGuild = (guild: QQ.Guild): Universal.Guild => ({
   id: guild.id,
   name: guild.name,
+  avatar: guild.icon,
 })
 
 export const decodeChannel = (channel: QQ.Channel): Universal.Channel => ({
   id: channel.id,
   name: channel.name,
-  // TODO support more channel types
-  type: Universal.Channel.Type.TEXT,
+  type: channel.type === QQ.ChannelType.TEXT ? Universal.Channel.Type.TEXT
+    : channel.type === QQ.ChannelType.VOICE ? Universal.Channel.Type.VOICE
+      : channel.type === QQ.ChannelType.GROUP ? Universal.Channel.Type.CATEGORY
+        : Universal.Channel.Type.TEXT,
+  parentId: channel.parent_id,
+  position: channel.position,
 })
 
 export const decodeUser = (user: QQ.User): Universal.User => ({
@@ -22,9 +27,10 @@ export const decodeUser = (user: QQ.User): Universal.User => ({
 })
 
 export const decodeGuildMember = (member: QQ.Member): Universal.GuildMember => ({
-  user: decodeUser(member.user),
+  user: member.user ? decodeUser(member.user) : undefined,
   nick: member.nick,
   roles: member.roles,
+  joinedAt: new Date(member.joined_at).valueOf(),
 })
 
 export function decodeGroupMessage(


### PR DESCRIPTION
主要修改点：
1. decode guild/channel 时，支持更多字段
2. 支持 `createChannel` api
3. 修复 `getMessage` 返回值的类型问题。这其实是 qq 侧的问题，实际接口返回值和文档相比多嵌套了一层导致。