### PR TITLE
fix(discord): update Modify interface to allow optional and nullable fields

### DIFF
--- a/adapters/discord/src/types/guild-member.ts
+++ b/adapters/discord/src/types/guild-member.ts
@@ -61,17 +61,19 @@ export namespace GuildMember {
     /** https://discord.com/developers/docs/resources/guild#modify-guild-member-json-params */
     export interface Modify {
       /** value to set user's nickname to */
-      nick: string
+      nick?: string | null
       /** array of role ids the member is assigned */
-      roles: snowflake[]
+      roles?: snowflake[] | null
       /** whether the user is muted in voice channels. Will throw a 400 if the user is not in a voice channel */
-      mute: boolean
+      mute?: boolean | null
       /** whether the user is deafened in voice channels. Will throw a 400 if the user is not in a voice channel */
-      deaf: boolean
+      deaf?: boolean | null
       /** id of channel to move user to (if they are connected to voice) */
-      channel_id: snowflake
+      channel_id?: snowflake | null
       /** when the user's timeout will expire and the user will be able to communicate in the guild again (up to 28 days in the future), set to null to remove timeout */
-      communication_disabled_until?: timestamp
+      communication_disabled_until?: timestamp | null
+      /** guild member flags */
+      flags?: integer | null
     }
 
     /** https://discord.com/developers/docs/resources/guild#modify-current-member-json-params */


### PR DESCRIPTION
文档中说明该接口的所有参数均为可选且可控，因此本次修正将 Modify Guild Member 的参数处理逻辑调整为与官方文档保持一致。
相关文档：https://docs.discord.com/developers/resources/guild#modify-guild-member