### PR TITLE
feat(discord): support ephemeral message

### DIFF
--- a/adapters/discord/src/index.ts
+++ b/adapters/discord/src/index.ts
@@ -22,6 +22,7 @@ type DiscordEvents<C extends Context = Context> = {
 declare module '@satorijs/core' {
   interface Session {
     discord?: Discord.Gateway.Payload & Discord.Internal
+    _discordEphemeral?: boolean
   }
 }
 

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -50,19 +50,35 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
     try {
       // propagate ephemeral flag from deferred response to all followup messages
       const sess = this.options?.session
-      const noEphemeral = !!(data && data._noEphemeral)
-      if (data?._noEphemeral) delete data._noEphemeral
-      if (sess?._discordEphemeral && data && !noEphemeral) {
-        if (data instanceof FormData) {
-          const raw = data.get('payload_json')
-          if (typeof raw === 'string') {
-            const payload = JSON.parse(raw)
+
+      // Determine if _noEphemeral was explicitly set — for plain objects it's on
+      // the object itself; for FormData it may be serialized inside payload_json.
+      let noEphemeral = !!(data && data._noEphemeral)
+
+      // Strip _noEphemeral from non-FormData before sending.
+      // Use a shallow copy to avoid mutating the caller's shared object
+      if (data?._noEphemeral && !(data instanceof FormData)) {
+        data = { ...data }
+        delete data._noEphemeral
+      }
+
+      // For FormData, _noEphemeral lives inside the payload_json string.
+      if (data instanceof FormData) {
+        const raw = data.get('payload_json')
+        if (typeof raw === 'string') {
+          const payload = JSON.parse(raw)
+          if (payload._noEphemeral) {
+            noEphemeral = true
+            delete payload._noEphemeral
+            data.set('payload_json', JSON.stringify(payload))
+          }
+          if (sess?._discordEphemeral && !noEphemeral) {
             payload.flags = (payload.flags || 0) | Message.Flag.EPHEMERAL
             data.set('payload_json', JSON.stringify(payload))
           }
-        } else {
-          data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
         }
+      } else if (sess?._discordEphemeral && data && !noEphemeral) {
+        data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
       }
       const url = await this.getUrl()
       const result = await this.bot.http.post<Message>(url, data, { headers })

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -50,11 +50,24 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
     try {
       // propagate ephemeral flag from deferred response to all followup messages
       const sess = this.options?.session
-      if (sess?._discordEphemeral && data && !(data instanceof FormData)) {
-        if (data._noEphemeral) {
-          delete data._noEphemeral
+      if (data) {
+        if (data instanceof FormData) {
+          const raw = data.get('payload_json')
+          if (typeof raw === 'string') {
+            const payload = JSON.parse(raw)
+            const noEphemeral = !!payload._noEphemeral
+            if (payload._noEphemeral) delete payload._noEphemeral
+            if (sess?._discordEphemeral && !noEphemeral) {
+              payload.flags = (payload.flags || 0) | Message.Flag.EPHEMERAL
+            }
+            data.set('payload_json', JSON.stringify(payload))
+          }
         } else {
-          data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
+          const noEphemeral = !!data._noEphemeral
+          if (data._noEphemeral) delete data._noEphemeral
+          if (sess?._discordEphemeral && !noEphemeral) {
+            data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
+          }
         }
       }
       const url = await this.getUrl()

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -48,6 +48,15 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
 
   async post(data?: any, headers?: any) {
     try {
+      // propagate ephemeral flag from deferred response to all followup messages
+      const sess = this.options?.session
+      if (sess?._discordEphemeral && data && !(data instanceof FormData)) {
+        if (data._noEphemeral) {
+          delete data._noEphemeral
+        } else {
+          data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
+        }
+      }
       const url = await this.getUrl()
       const result = await this.bot.http.post<Message>(url, data, { headers })
       const session = this.bot.session()
@@ -378,6 +387,11 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
       this.buffer = ''
       this.mode = 'default'
     } else if (type === 'message' && !attrs.forward) {
+      if (attrs.ephemeral) {
+        this.addition.flags = (this.addition.flags || 0) | Message.Flag.EPHEMERAL
+      } else if (attrs.ephemeral === false) {
+        this.addition._noEphemeral = true
+      }
       if (this.mode === 'figure') {
         await this.render(children)
         this.buffer += '\n'

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -50,12 +50,10 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
     try {
       // propagate ephemeral flag from deferred response to all followup messages
       const sess = this.options?.session
-      if (sess?._discordEphemeral && data && !(data instanceof FormData)) {
-        if (data._noEphemeral) {
-          delete data._noEphemeral
-        } else {
-          data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
-        }
+      const noEphemeral = !!(data && data._noEphemeral)
+      if (data?._noEphemeral) delete data._noEphemeral
+      if (sess?._discordEphemeral && data && !(data instanceof FormData) && !noEphemeral) {
+        data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
       }
       const url = await this.getUrl()
       const result = await this.bot.http.post<Message>(url, data, { headers })

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -52,8 +52,17 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
       const sess = this.options?.session
       const noEphemeral = !!(data && data._noEphemeral)
       if (data?._noEphemeral) delete data._noEphemeral
-      if (sess?._discordEphemeral && data && !(data instanceof FormData) && !noEphemeral) {
-        data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
+      if (sess?._discordEphemeral && data && !noEphemeral) {
+        if (data instanceof FormData) {
+          const raw = data.get('payload_json')
+          if (typeof raw === 'string') {
+            const payload = JSON.parse(raw)
+            payload.flags = (payload.flags || 0) | Message.Flag.EPHEMERAL
+            data.set('payload_json', JSON.stringify(payload))
+          }
+        } else {
+          data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
+        }
       }
       const url = await this.getUrl()
       const result = await this.bot.http.post<Message>(url, data, { headers })

--- a/adapters/discord/src/message.ts
+++ b/adapters/discord/src/message.ts
@@ -50,24 +50,11 @@ export class DiscordMessageEncoder<C extends Context = Context> extends MessageE
     try {
       // propagate ephemeral flag from deferred response to all followup messages
       const sess = this.options?.session
-      if (data) {
-        if (data instanceof FormData) {
-          const raw = data.get('payload_json')
-          if (typeof raw === 'string') {
-            const payload = JSON.parse(raw)
-            const noEphemeral = !!payload._noEphemeral
-            if (payload._noEphemeral) delete payload._noEphemeral
-            if (sess?._discordEphemeral && !noEphemeral) {
-              payload.flags = (payload.flags || 0) | Message.Flag.EPHEMERAL
-            }
-            data.set('payload_json', JSON.stringify(payload))
-          }
+      if (sess?._discordEphemeral && data && !(data instanceof FormData)) {
+        if (data._noEphemeral) {
+          delete data._noEphemeral
         } else {
-          const noEphemeral = !!data._noEphemeral
-          if (data._noEphemeral) delete data._noEphemeral
-          if (sess?._discordEphemeral && !noEphemeral) {
-            data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
-          }
+          data.flags = (data.flags || 0) | Message.Flag.EPHEMERAL
         }
       }
       const url = await this.getUrl()

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -315,7 +315,7 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     if (ephemeral) session._discordEphemeral = true
     await bot.internal.createInteractionResponse(input.d.id, input.d.token, {
       type: Discord.Interaction.CallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
-      ...(ephemeral ? { data: { flags: 64 } } : {}),
+      ...(ephemeral ? { data: { flags: Discord.Message.Flag.EPHEMERAL } } : {}),
     })
     session.type = 'interaction/command'
     session.isDirect = !input.d.guild_id

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -170,8 +170,12 @@ export async function decodeMessage<C extends Context = Context>(
     try {
       message.quote = await bot.getMessage(channel_id!, message_id, false)
     } catch (e) {
-      // ephemeral messages or deleted messages cannot be fetched via REST API
-      bot.logger.debug('failed to fetch quoted message %s: %o', message_id, e)
+      if (bot.http.isError(e) && e.response?.data?.code === 10008) {
+        // ephemeral or deleted messages cannot be fetched via REST API
+        bot.logger.debug('failed to fetch quoted message %s', message_id)
+      } else {
+        throw e
+      }
     }
   }
 
@@ -235,8 +239,12 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     try {
       message = await bot._getMessage(input.d.channel_id!, input.d.id!)
     } catch (e) {
-      // ephemeral messages cannot be fetched via REST API, fall back to partial payload
-      bot.logger.debug('failed to fetch updated message %s: %o', input.d.id!, e)
+      if (bot.http.isError(e) && e.response?.data?.code === 10008) {
+        // ephemeral messages cannot be fetched via REST API, fall back to partial payload
+        bot.logger.debug('failed to fetch updated message %s', input.d.id!)
+      } else {
+        throw e
+      }
     }
     // Unlike creates, message updates may contain only a subset of the full message object payload
     // https://discord.com/developers/docs/topics/gateway-events#message-update

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -319,7 +319,9 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     const data = input.d.data as Discord.InteractionData.ApplicationCommand
     const command = bot.commands.find(cmd => cmd.name === data.name)
     if (!command) return
-    const ephemeral = !!(command as any).ephemeral
+    const cmd = (bot.ctx.root as any).$commander?._commandList
+      ?.find((c: any) => c.name === data.name)
+    const ephemeral = !!cmd?.config?.ephemeral
     if (ephemeral) session._discordEphemeral = true
     await bot.internal.createInteractionResponse(input.d.id, input.d.token, {
       type: Discord.Interaction.CallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -319,8 +319,9 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     const data = input.d.data as Discord.InteractionData.ApplicationCommand
     const command = bot.commands.find(cmd => cmd.name === data.name)
     if (!command) return
-    const cmd = (bot.ctx.root as any).$commander?._commandList
-      ?.find((c: any) => c.name === data.name)
+    const cmd = (bot.ctx.root as unknown as {
+      $commander?: { _commandList?: { name: string; config?: { ephemeral?: boolean } }[] }
+    }).$commander?._commandList?.find(c => c.name === data.name)
     const ephemeral = !!cmd?.config?.ephemeral
     if (ephemeral) session._discordEphemeral = true
     await bot.internal.createInteractionResponse(input.d.id, input.d.token, {

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -170,7 +170,7 @@ export async function decodeMessage<C extends Context = Context>(
     try {
       message.quote = await bot.getMessage(channel_id!, message_id, false)
     } catch (e) {
-      if (bot.http.isError(e) && e.response?.data?.code === 10008) {
+      if (e instanceof Error && /"code"\s*:\s*10008/.test(e.message)) {
         // ephemeral or deleted messages cannot be fetched via REST API
         bot.logger.debug('failed to fetch quoted message %s', message_id)
       } else {
@@ -239,7 +239,7 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     try {
       message = await bot._getMessage(input.d.channel_id!, input.d.id!)
     } catch (e) {
-      if (bot.http.isError(e) && e.response?.data?.code === 10008) {
+      if (e instanceof Error && /"code"\s*:\s*10008/.test(e.message)) {
         // ephemeral messages cannot be fetched via REST API, fall back to partial payload
         bot.logger.debug('failed to fetch updated message %s', input.d.id!)
       } else {

--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -167,7 +167,12 @@ export async function decodeMessage<C extends Context = Context>(
   // THREAD_STARTER_MESSAGE (21) 事件下，message_reference 有 message_id
   if (details && data.message_reference?.message_id) {
     const { message_id, channel_id } = data.message_reference
-    message.quote = await bot.getMessage(channel_id!, message_id, false)
+    try {
+      message.quote = await bot.getMessage(channel_id!, message_id, false)
+    } catch (e) {
+      // ephemeral messages or deleted messages cannot be fetched via REST API
+      bot.logger.debug('failed to fetch quoted message %s: %o', message_id, e)
+    }
   }
 
   message.createdAt = new Date(data.timestamp).valueOf()
@@ -226,7 +231,13 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     // if (!session.content) return
   } else if (input.t === 'MESSAGE_UPDATE') {
     session.type = 'message-updated'
-    const message = await bot._getMessage(input.d.channel_id!, input.d.id!)
+    let message = input.d as Discord.Message
+    try {
+      message = await bot._getMessage(input.d.channel_id!, input.d.id!)
+    } catch (e) {
+      // ephemeral messages cannot be fetched via REST API, fall back to partial payload
+      bot.logger.debug('failed to fetch updated message %s: %o', input.d.id!, e)
+    }
     // Unlike creates, message updates may contain only a subset of the full message object payload
     // https://discord.com/developers/docs/topics/gateway-events#message-update
     await decodeMessage(bot, message, session.event.message = {}, session.event)
@@ -300,8 +311,11 @@ export async function adaptSession<C extends Context>(bot: DiscordBot<C>, input:
     const data = input.d.data as Discord.InteractionData.ApplicationCommand
     const command = bot.commands.find(cmd => cmd.name === data.name)
     if (!command) return
+    const ephemeral = !!(command as any).ephemeral
+    if (ephemeral) session._discordEphemeral = true
     await bot.internal.createInteractionResponse(input.d.id, input.d.token, {
       type: Discord.Interaction.CallbackType.DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+      ...(ephemeral ? { data: { flags: 64 } } : {}),
     })
     session.type = 'interaction/command'
     session.isDirect = !input.d.guild_id


### PR DESCRIPTION
在 Discord 斜线指令和回调中支持 ephemeral messages，回复仅对调用者可见。
<img width="374" height="385" alt="image" src="https://github.com/user-attachments/assets/807c70aa-2900-463a-b518-714313b35abb" />

### 使用

> 没用过satori，就拿koishi举例了www

通过 `ctx.command()` 的 config 参数设置 `ephemeral: true`，该命令所有回复默认仅调用者可见，可通过 `<message ephemeral="false">` 单独覆盖某条消息的设置（对第一条消息无效，详见结尾的说明）：

```ts
import { Command } from 'koishi'

ctx.command('test/ephemeral1', { ephemeral: true } as Command.Config).action(async ({ session }) => {
  await session.send(h('测试1'))                                      // 仅调用者可见（不可修改）
  await session.send(h('message', { ephemeral: false }, '测试2'))        // 公开（覆盖命令级配置）
  await session.send('测试3')                                          // 仅调用者可见
})

ctx.command('test/ephemeral2').action(async ({ session }) => {
  await session.send('测试4')                                          // 公开（不可修改）
  await session.send(h('message', { ephemeral: true }, '测试5'))         // 仅调用者可见
  await session.send('测试6')                                          // 公开
})
```

### 实现

- `utils.ts`：收到 slash command 交互时，在 `bot.commands` 中查找对应命令，读取其 `ephemeral` 配置，标记 `session._discordEphemeral`
- `message.ts`：每次 `post()` 发送 followup 消息时，检查 session 标记，自动补 `flags: 64`（`Message.Flag.EPHEMERAL`）；如果消息显式设置了 `ephemeral: false`（通过 `_noEphemeral` 标记），则跳过自动补 flags，实现单条覆盖
- `message.ts`：处理了 ephemeral 消息无法通过 REST API 获取的 404 情况（”仅调用者可见“也意味着机器人不可见），捕获后降级为 debug log
 - `index.ts`: 扩展 `Session` 类型，增加`_discordEphemeral` 字段记录状态


### 一些说明

#### 关于 `as Command.Config`

其实可以通过`declare module 'koishi'`实现
不过由于这是satori的仓库，于是没放

#### 覆盖控制对第一条消息无效

因为discord的斜杠指令是需要在被调用时立刻回一个`DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE`消息，再回复这个消息的同时就得决定是否是ephemeral（用于决定"正在响应..."本身及第一条消息的展示范围），所以第一条消息只能强制跟随指令的设置，暂时没想到什么更好的办法，欢迎优化（