### PR TITLE
fix(discord): cap command options at 25 on v4

### DIFF
--- a/adapters/discord/src/utils.ts
+++ b/adapters/discord/src/utils.ts
@@ -417,7 +417,7 @@ export const encodeCommand = (cmd: Universal.Command): Discord.ApplicationComman
   ...encodeDescription(cmd),
   name: cmd.name,
   type: Discord.ApplicationCommand.Type.CHAT_INPUT,
-  options: encodeCommandOptions(cmd),
+  options: encodeCommandOptions(cmd).slice(0, 25),
 })
 
 const decodeArgv = (
@@ -480,5 +480,5 @@ export function encodeCommandOptions(cmd: Universal.Command): Discord.Applicatio
       })
     }
   }
-  return result.sort((a, b) => +b.required! - +a.required!)
+  return result.sort((a, b) => +b.required! - +a.required!).slice(0, 25)
 }


### PR DESCRIPTION
Discord rejects the entire command-registration request with a 400 once any command carries more than 25 options, so one oversized command takes every command in the batch down with it.

`main` already caps this (#409, `f2ccd69`), but that change never reached `v4`, and `v4` is the line npm publishes from: `@satorijs/adapter-discord@4.6.2` still sends the full option list, so users on the released line still hit the 400.

This is the same two-line change as #409, applied to `v4`:

- `encodeCommand()` caps `encodeCommandOptions(cmd)` at 25
- `encodeCommandOptions()` caps its sorted result at 25

The Discord response body is quoted in koishijs/koishi#1543.

No other files are touched.