### PR TITLE
fix(core): guard Bot.dispose() against an already-disposed satori service

### DIFF
--- a/packages/core/src/bot.ts
+++ b/packages/core/src/bot.ts
@@ -93,7 +93,11 @@ export abstract class Bot<C extends Context = Context, T = any> {
   }
 
   dispose() {
-    const index = this.ctx.bots.findIndex(bot => bot.sid === this.sid)
+    // `ctx.bots` is the `satori` service's mixin, and a Bot disposer runs inside
+    // cordis's teardown loop; when that service is torn down first the mixin is
+    // already gone, so there is nothing left to unregister from. Same guard the
+    // `status` setter below already applies.
+    const index = this.ctx.bots?.findIndex(bot => bot.sid === this.sid) ?? -1
     if (index >= 0) {
       this.ctx.bots.splice(index, 1)
       this.context.emit('bot-removed', this)


### PR DESCRIPTION
`Bot.dispose()` reads `this.ctx.bots` without a guard, while the same class already guards it in the `status` setter:

```ts
dispose() {
  const index = this.ctx.bots.findIndex(bot => bot.sid === this.sid)   // ← no `?.`
  ...
}

set status(value) {
  ...
  if (this.ctx.bots?.some(bot => bot.sid === this.sid)) {              // ← guarded
```

`ctx.bots` is the `satori` service's mixin, and a Bot's disposer runs inside cordis's teardown loop. When that service is torn down first the mixin is already gone, so this line throws from inside the loop — where cordis logs and swallows it, so it never surfaces as a failed `app.stop()`.

Fixes koishijs/koishi#1525.

### Reproduction

Against the published `@satorijs/core@4.6.0` + `cordis@3.18.1` — mount `Satori`, mount a minimal `Bot` subclass, then `start()` / `stop()`:

```
ctx.bots at dispose() entry : undefined
dispose() threw             : TypeError: Cannot read properties of undefined (reading 'findIndex')
app.stop() itself threw     : no (cordis logs and swallows it)
```

The stack shape matches the report: `event <dispose>` → `Array.filter` → `ForkScope.reset` → `fork <root>`. With the guard, `dispose()` does not throw.

Also verified in-repo against the locally built `packages/core/lib/index.mjs`: reproduced with this line stashed, clean with it applied.

### On CI

The `Unit Test` job is red on `v4`, and it is red without this change too. Two layers, both pre-existing:

1. `packages/{protocol,element}/tests/*.spec.ts` import `'../src'` — a directory — which Node ESM rejects with `ERR_UNSUPPORTED_DIR_IMPORT`.
2. Making those explicit clears the first layer, and all specs then fail with `ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX` (`namespace` declaration / parameter property): the runner strips types with Node's strip-only mode, and `--import tsx` does not take effect.

`1e342e0` is green and `fbc093f` ("chore: bump versions", yakumo `^1.0.0` → `^3.2.1`) is the first red one on this branch, which points at the runner rather than at source. I left both alone — that reads like a separate fix, and this PR is only the one line.

For the same reason there is no regression test here: no spec that imports satori's TS source can currently run. Happy to add one once the runner is sorted.

### Alternative

Making the dependency explicit (`static inject = ['satori']`) fixes it as well — cordis then tears the Bot down before the service it reads, so `ctx.bots` is still an array at dispose time and nothing throws. I verified that variant too and went with the guard because it is the minimal change and matches what `status` already does; you would know better which layer is right.
